### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Non-Magical Multiple Dispatch
 
 [![Build Status](https://travis-ci.org/twneale/nmmd.svg?branch=master)](https://travis-ci.org/twneale/nmmd)
 [![Coverage Status](https://coveralls.io/repos/twneale/nmmd/badge.png?branch=master)](https://coveralls.io/r/twneale/nmmd?branch=master)
-[![Latest Version](https://pypip.in/version/nmmd/badge.png)](https://pypi.python.org/pypi/nmmd/)
-[![Download Format](https://pypip.in/format/nmmd/badge.png)](https://pypi.python.org/pypi/nmmd/)
+[![Latest Version](https://img.shields.io/pypi/v/nmmd.svg)](https://pypi.python.org/pypi/nmmd/)
+[![Download Format](https://img.shields.io/pypi/format/nmmd.svg)](https://pypi.python.org/pypi/nmmd/)
 
 This package tries to provide an implemention of multiple dispatch without magical inspection of stack frames or other lunacy.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nmmd))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nmmd`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.